### PR TITLE
fix: Correct multi-index flattening logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/atualiza_sheets.py
+++ b/atualiza_sheets.py
@@ -65,7 +65,7 @@ for ticker in TICKERS:
 
             # flatten multiindex (caso haja)
             if isinstance(df.columns, pd.MultiIndex):
-                df.columns = [col[-1] for col in df.columns]
+                df.columns = [col[0] for col in df.columns]
 
             df.reset_index(inplace=True)
             df.rename(columns={


### PR DESCRIPTION
The original code to flatten a multi-index DataFrame was incorrect. It used the last element of the column tuple, which is the ticker symbol, instead of the first element, which is the metric. This would cause issues if the script were modified to download data for multiple tickers at once.

The fix changes the indexing to correctly select the metric as the column name. A .gitignore file was also added to exclude __pycache__ and .pyc files.